### PR TITLE
Version 0.41.0. Rebranding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ All notable changes to this project will be documented in this file.
 ### New
 
 - Produces masterchain block for each workchain block. 
-- Added ability to update blockchain config with node restart (without killing the database). After [changing the config](https://github.com/tonlabs/evernode-se#how-to-change-the-blockchain-configuration) stop and start the node to apply it. It will produce new key block from the new config. 
+- Added ability to update blockchain config with node restart (without killing the database). After [changing the config](https://github.com/everx-labs/evernode-se#how-to-change-the-blockchain-configuration) stop and start the node to apply it. It will produce new key block from the new config. 
 - `CapSignatureWithId` capability is supported: `global_id` parameter is used as a `signature_id` if `CapSignatureWithId` cap is turned  
     on in the blockchain config.
 
@@ -226,7 +226,7 @@ All notable changes to this project will be documented in this file.
 
 ## 0.28.4 Jul 07, 2021
 ### Fixed
-- [tvm.rawReserve](https://github.com/tonlabs/TON-Solidity-Compiler/blob/master/API.md#tvmrawreserve) function now correctly reacts on all flags.
+- [tvm.rawReserve](https://github.com/everx-labs/TVM-Solidity-Compiler/blob/master/API.md#tvmrawreserve) function now correctly reacts on all flags.
 
 ## 0.28.3 May 20, 2021
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aes"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cipher 0.3.0",
+ "cpufeatures",
+ "opaque-debug",
+]
+
+[[package]]
 name = "aes-ctr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,7 +37,7 @@ checksum = "7729c3cde54d67063be556aeac75a81330d802f0259500ca40cb52967f975763"
 dependencies = [
  "aes-soft",
  "aesni",
- "cipher",
+ "cipher 0.2.5",
  "ctr",
 ]
 
@@ -35,7 +47,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be14c7498ea50828a38d0e24a765ed2effe92a705885b57d029cd67d45744072"
 dependencies = [
- "cipher",
+ "cipher 0.2.5",
  "opaque-debug",
 ]
 
@@ -45,15 +57,26 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
 dependencies = [
- "cipher",
+ "cipher 0.2.5",
  "opaque-debug",
 ]
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.14",
+ "once_cell",
+ "version_check 0.9.4",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if 1.0.0",
  "once_cell",
@@ -63,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -96,15 +119,54 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
+
+[[package]]
+name = "api_derive"
+version = "1.46.1"
+source = "git+https://github.com/everx-labs/ever-sdk.git?tag=1.46.1#ac13c266f8a8609b77cce31a21a0a76cc65fda47"
+dependencies = [
+ "api_info",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "api_info"
+version = "1.46.1"
+source = "git+https://github.com/everx-labs/ever-sdk.git?tag=1.46.1#ac13c266f8a8609b77cce31a21a0a76cc65fda47"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
 
 [[package]]
 name = "arc-swap"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
+name = "arrayref"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+
+[[package]]
+name = "async-trait"
+version = "0.1.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
 
 [[package]]
 name = "atty"
@@ -123,20 +185,20 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg 1.2.0",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
  "cc",
@@ -146,6 +208,12 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base58"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5024ee8015f02155eee35c711107ddd9a9bf3cb689cf2a9089c97e79b6e1ae83"
 
 [[package]]
 name = "base64"
@@ -168,15 +236,36 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+
+[[package]]
+name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -186,9 +275,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "block-buffer"
@@ -209,6 +298,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-modes"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cb03d1bed155d89dce0f845b7899b18a9a163e148fd004e1c28421a783e2d8e"
+dependencies = [
+ "block-padding",
+ "cipher 0.3.0",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
+
+[[package]]
+name = "blst"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c94087b935a822949d3291a9989ad2b2051ea141eda0fd4e478a75f6aa3e604b"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.7.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79ad7fb2dd38f3dabd76b09c6a5a20c038fc0213ef1e9afd30eb777f120f019"
+checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
 dependencies = [
  "memchr",
  "serde",
@@ -235,9 +352,9 @@ checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "byteorder"
@@ -258,18 +375,19 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "065a29261d53ba54260972629f9ca6bffa69bac13cd1fed61420f7fa68b9f8bd"
 dependencies = [
  "jobserver",
  "libc",
+ "once_cell",
 ]
 
 [[package]]
@@ -285,17 +403,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.31"
+name = "chacha20"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+checksum = "ed8738f14471a99f0e316c327e68fc82a3611cc2895fcb604b89eedaf8f39d95"
+dependencies = [
+ "cipher 0.2.5",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -303,6 +430,15 @@ name = "cipher"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
  "generic-array",
 ]
@@ -342,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "cookie"
@@ -352,8 +488,19 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
 dependencies = [
- "time",
+ "time 0.1.45",
  "url 1.7.2",
+]
+
+[[package]]
+name = "cookie"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7efb37c3e1ccb1ff97164ad95ac1606e8ccd35b3fa0a7d99a304c7f4a428cc24"
+dependencies = [
+ "percent-encoding 2.3.1",
+ "time 0.3.36",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -362,23 +509,40 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46750b3f362965f197996c4448e4a0935e791bf7d6631bfce9ee0af3d24c919c"
 dependencies = [
- "cookie",
+ "cookie 0.12.0",
  "failure",
  "idna 0.1.5",
- "log 0.4.20",
- "publicsuffix",
+ "log 0.4.21",
+ "publicsuffix 1.5.6",
  "serde",
  "serde_json",
- "time",
+ "time 0.1.45",
  "try_from",
  "url 1.7.2",
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.9.3"
+name = "cookie_store"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+checksum = "387461abbc748185c3a6e1673d826918b450b87ff22639429c694619a83b6cf6"
+dependencies = [
+ "cookie 0.17.0",
+ "idna 0.3.0",
+ "log 0.4.21",
+ "publicsuffix 2.2.3",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time 0.3.36",
+ "url 2.5.0",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -386,15 +550,15 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
@@ -410,24 +574,24 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.0.1"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
 dependencies = [
  "crc-catalog",
 ]
 
 [[package]]
 name = "crc-catalog"
-version = "2.2.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -449,7 +613,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg 1.2.0",
  "cfg-if 0.1.10",
  "crossbeam-utils",
  "lazy_static",
@@ -475,10 +639,16 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg 1.2.0",
  "cfg-if 0.1.10",
  "lazy_static",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
@@ -491,12 +661,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
 name = "ctr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb4a30d54f7443bf3d6191dcd486aca19e67cb3c49fa7a06a319966346707e7f"
 dependencies = [
- "cipher",
+ "cipher 0.2.5",
 ]
 
 [[package]]
@@ -514,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.1"
+version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -531,23 +721,32 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek-derive"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "der"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -617,7 +816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
- "signature 2.1.0",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -636,29 +835,30 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7277392b266383ef8396db7fdeb1e77b6c52fed775f5df15bb24f35b72156980"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
- "curve25519-dalek 4.1.1",
+ "curve25519-dalek 4.1.2",
  "ed25519 2.2.3",
  "rand_core 0.6.4",
  "serde",
  "sha2 0.10.8",
+ "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.33"
+version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -671,47 +871,268 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.5"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ever-struct"
+version = "1.0.32"
+source = "git+https://github.com/everx-labs/ever-struct.git?tag=1.0.32#45720a776c5364dbae956a10d9708a571a9d3fae"
+dependencies = [
+ "anyhow",
+ "ever_block 1.10.0",
+ "failure",
+ "hex-literal",
+]
+
+[[package]]
+name = "ever_abi"
+version = "2.5.1"
+source = "git+https://github.com/everx-labs/ever-abi.git?tag=2.5.1#e80c51cd9b890e036c31a1dab7e798cc9f8e9ba5"
+dependencies = [
+ "base64 0.10.1",
+ "byteorder",
+ "chrono",
+ "ever_block 1.10.0",
+ "failure",
+ "hex 0.3.2",
+ "num-bigint",
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "ever_abi"
+version = "2.5.3"
+source = "git+https://github.com/everx-labs/ever-abi.git?tag=2.5.3#51beeb76416ac2fb8051c3a0d432e24c649b39fa"
+dependencies = [
+ "base64 0.10.1",
+ "byteorder",
+ "chrono",
+ "ever_block 1.10.2",
+ "failure",
+ "hex 0.3.2",
+ "num-bigint",
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "ever_block"
+version = "1.10.0"
+source = "git+https://github.com/everx-labs/ever-block.git?tag=1.10.0#f7c5194d082e0d2412571e981aa0b1b500c559da"
+dependencies = [
+ "aes-ctr",
+ "base64 0.13.1",
+ "blst",
+ "crc 3.2.1",
+ "curve25519-dalek 4.1.2",
+ "ed25519 2.2.3",
+ "ed25519-dalek 2.1.1",
+ "failure",
+ "hex 0.4.3",
+ "lazy_static",
+ "lockfree",
+ "log 0.4.21",
+ "num",
+ "num-derive",
+ "num-traits",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "smallvec 1.13.2",
+ "x25519-dalek",
+]
+
+[[package]]
+name = "ever_block"
+version = "1.10.2"
+source = "git+https://github.com/everx-labs/ever-block?tag=1.10.2#e2a03f33f7913791bf896443261925b6a1eb59ae"
+dependencies = [
+ "aes-ctr",
+ "base64 0.13.1",
+ "blst",
+ "crc 3.2.1",
+ "curve25519-dalek 4.1.2",
+ "ed25519 2.2.3",
+ "ed25519-dalek 2.1.1",
+ "failure",
+ "hex 0.4.3",
+ "lazy_static",
+ "lockfree",
+ "log 0.4.21",
+ "num",
+ "num-derive",
+ "num-traits",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "smallvec 1.13.2",
+ "x25519-dalek",
+]
+
+[[package]]
+name = "ever_block_json"
+version = "0.8.3"
+source = "git+https://github.com/everx-labs/ever-block-json.git?tag=0.8.3#0241c30102e88f8bd049e37e4c616805033ec279"
+dependencies = [
+ "base64 0.13.1",
+ "ever_block 1.10.0",
+ "failure",
+ "hex 0.4.3",
+ "lazy_static",
+ "log 0.4.21",
+ "metrics",
+ "num",
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "ton_api 0.3.77",
+]
+
+[[package]]
+name = "ever_block_json"
+version = "0.8.6"
+source = "git+https://github.com/everx-labs/ever-block-json?tag=0.8.6#410d00dc6c1c558e782a375f9fad7b94a7641d63"
+dependencies = [
+ "ever_block 1.10.2",
+ "failure",
+ "hex 0.4.3",
+ "lazy_static",
+ "log 0.4.21",
+ "metrics",
+ "num",
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "ton_api 0.3.79",
+]
+
+[[package]]
+name = "ever_executor"
+version = "1.17.3"
+source = "git+https://github.com/everx-labs/ever-executor.git?tag=1.17.3#ce3041ae2e2c5f6896cc8cfb6cfe33845d9da9fc"
+dependencies = [
+ "ever_block 1.10.0",
+ "ever_vm 2.1.2",
+ "failure",
+ "lazy_static",
+ "log 0.4.21",
+]
+
+[[package]]
+name = "ever_executor"
+version = "1.17.6"
+source = "git+https://github.com/everx-labs/ever-executor?tag=1.17.6#ef126b73d0f02ad8a420994edc6d1a3894f92654"
+dependencies = [
+ "ever_block 1.10.2",
+ "ever_vm 2.1.5",
+ "failure",
+ "lazy_static",
+ "log 0.4.21",
+]
+
+[[package]]
+name = "ever_vm"
+version = "2.1.2"
+source = "git+https://github.com/everx-labs/ever-vm.git?tag=2.1.2#75c73db756157305788e7323ce5f7f8ad8eb4da8"
+dependencies = [
+ "diffy",
+ "ed25519 1.5.3",
+ "ed25519-dalek 1.0.1",
+ "ever_block 1.10.0",
+ "failure",
+ "hex 0.4.3",
+ "lazy_static",
+ "log 0.4.21",
+ "num",
+ "num-traits",
+ "rand 0.7.3",
+ "similar",
+ "zstd",
+]
+
+[[package]]
+name = "ever_vm"
+version = "2.1.5"
+source = "git+https://github.com/everx-labs/ever-vm?tag=2.1.5#6d7e851a25f4713c465bf93e83cfba00047029bb"
+dependencies = [
+ "diffy",
+ "ever_block 1.10.2",
+ "failure",
+ "hex 0.4.3",
+ "lazy_static",
+ "log 0.4.21",
+ "num",
+ "num-traits",
+ "similar",
+ "zstd",
 ]
 
 [[package]]
 name = "evernode_se"
-version = "0.39.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
  "clap",
- "ed25519-dalek 1.0.1",
+ "ed25519-dalek 2.1.1",
+ "ever_abi 2.5.3",
+ "ever_block 1.10.2",
+ "ever_block_json 0.8.6",
+ "ever_executor 1.17.6",
+ "ever_vm 2.1.5",
  "failure",
  "hex 0.4.3",
- "http 0.2.9",
+ "http 0.2.12",
  "iron",
  "jsonrpc-http-server",
  "lazy_static",
  "lockfree",
- "log 0.4.20",
+ "log 0.4.21",
  "log4rs",
  "num",
  "num-traits",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.2",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.9.24",
  "router",
  "serde",
  "serde_derive",
  "serde_json",
  "thiserror",
- "ton_abi",
- "ton_block",
- "ton_block_json",
- "ton_executor",
- "ton_types",
- "ton_vm",
+]
+
+[[package]]
+name = "evernode_se_integration_tests"
+version = "0.1.0"
+dependencies = [
+ "base64 0.13.1",
+ "ed25519-dalek 1.0.1",
+ "ever_block 1.10.2",
+ "failure",
+ "hex 0.4.3",
+ "lazy_static",
+ "rand 0.7.3",
+ "reqwest 0.11.27",
+ "serde_json",
+ "tokio 1.37.0",
+ "ton_client",
 ]
 
 [[package]]
@@ -744,21 +1165,21 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.1"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0870c84016d4b481be5c9f323c24f65e31e901ae618f0e80f4308fb00de1d2d"
+checksum = "38793c55593b33412e3ae40c2c9781ffaa6f438f6f8c10f24e71846fbd7ae01e"
 
 [[package]]
 name = "flate2"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -787,11 +1208,11 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
- "percent-encoding 2.3.0",
+ "percent-encoding 2.3.1",
 ]
 
 [[package]]
@@ -824,9 +1245,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -839,9 +1260,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -849,9 +1270,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-cpupool"
@@ -865,9 +1286,9 @@ dependencies = [
 
 [[package]]
 name = "futures-executor"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -876,38 +1297,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-util"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -938,15 +1359,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -955,21 +1378,27 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "globset"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759c97c1e17c55525b57192c06a267cda0ac5210b222d6b82189a2338fa1c13d"
+checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
 dependencies = [
  "aho-corasick",
- "bstr 1.7.0",
- "fnv",
- "log 0.4.20",
- "regex",
+ "bstr 1.9.1",
+ "log 0.4.21",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -984,10 +1413,29 @@ dependencies = [
  "futures 0.1.31",
  "http 0.1.21",
  "indexmap 1.9.3",
- "log 0.4.20",
+ "log 0.4.21",
  "slab",
  "string",
  "tokio-io",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+dependencies = [
+ "bytes 1.6.0",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio 1.37.0",
+ "tokio-util 0.7.10",
+ "tracing",
 ]
 
 [[package]]
@@ -995,12 +1443,15 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
-version = "0.14.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hermit-abi"
@@ -1013,9 +1464,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -1030,6 +1481,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-literal"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
+
+[[package]]
+name = "hmac"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
+dependencies = [
+ "crypto-mac 0.8.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+dependencies = [
+ "crypto-mac 0.11.1",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac-drbg"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
+dependencies = [
+ "digest 0.9.0",
+ "generic-array",
+ "hmac 0.8.1",
+]
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "http"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,13 +1539,13 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.9"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "fnv",
- "itoa 1.0.9",
+ "itoa 1.0.11",
 ]
 
 [[package]]
@@ -1065,12 +1562,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
- "bytes 1.5.0",
- "http 0.2.9",
+ "bytes 1.6.0",
+ "http 0.2.12",
  "pin-project-lite",
 ]
 
@@ -1104,7 +1601,7 @@ dependencies = [
  "log 0.3.9",
  "mime 0.2.6",
  "num_cpus",
- "time",
+ "time 0.1.45",
  "traitobject",
  "typeable",
  "unicase 1.4.2",
@@ -1120,16 +1617,16 @@ dependencies = [
  "bytes 0.4.12",
  "futures 0.1.31",
  "futures-cpupool",
- "h2",
+ "h2 0.1.26",
  "http 0.1.21",
  "http-body 0.1.0",
  "httparse",
  "iovec",
  "itoa 0.4.8",
- "log 0.4.20",
+ "log 0.4.21",
  "net2",
  "rustc_version 0.2.3",
- "time",
+ "time 0.1.45",
  "tokio 0.1.22",
  "tokio-buf",
  "tokio-executor",
@@ -1143,22 +1640,23 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.27"
+version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
 dependencies = [
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 0.2.9",
- "http-body 0.4.5",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
- "itoa 1.0.9",
+ "itoa 1.0.11",
  "pin-project-lite",
- "socket2 0.4.10",
- "tokio 1.33.0",
+ "socket2",
+ "tokio 1.37.0",
  "tower-service",
  "tracing",
  "want 0.3.1",
@@ -1178,10 +1676,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.58"
+name = "hyper-tls"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes 1.6.0",
+ "hyper 0.14.28",
+ "native-tls",
+ "tokio 1.37.0",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1224,13 +1735,29 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.4.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "index-fixed"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161ceaf2f41b6cd3f6502f5da085d4ad4393a51e0c70ed2fce1d5698d798fae"
 
 [[package]]
 name = "indexmap"
@@ -1238,18 +1765,18 @@ version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg 1.2.0",
  "hashbrown 0.12.3",
 ]
 
 [[package]]
 name = "indexmap"
-version = "2.0.2"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.2",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1269,6 +1796,12 @@ checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "iron"
@@ -1294,24 +1827,24 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.27"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1322,10 +1855,10 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14f7f76aef2d054868398427f6c54943cf3d1caa9a7ec7d0c38d69df97a965eb"
 dependencies = [
- "futures 0.3.29",
+ "futures 0.3.30",
  "futures-executor",
  "futures-util",
- "log 0.4.20",
+ "log 0.4.21",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1337,11 +1870,11 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1dea6e07251d9ce6a552abfb5d7ad6bc290a4596c8dcc3d795fae2bbdc1f3ff"
 dependencies = [
- "futures 0.3.29",
- "hyper 0.14.27",
+ "futures 0.3.30",
+ "hyper 0.14.28",
  "jsonrpc-core",
  "jsonrpc-server-utils",
- "log 0.4.20",
+ "log 0.4.21",
  "net2",
  "parking_lot 0.11.2",
  "unicase 2.7.0",
@@ -1353,15 +1886,15 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4fdea130485b572c39a460d50888beb00afb3e35de23ccd7fad8ff19f0e0d4"
 dependencies = [
- "bytes 1.5.0",
- "futures 0.3.29",
+ "bytes 1.6.0",
+ "futures 0.3.30",
  "globset",
  "jsonrpc-core",
  "lazy_static",
- "log 0.4.20",
- "tokio 1.33.0",
+ "log 0.4.21",
+ "tokio 1.37.0",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.6.10",
  "unicase 2.7.0",
 ]
 
@@ -1389,21 +1922,63 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
+name = "libsecp256k1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+checksum = "c9d220bc1feda2ac231cb78c3d26f27676b8cf82c96971f7aeef3d0cf2797c73"
+dependencies = [
+ "arrayref",
+ "base64 0.12.3",
+ "digest 0.9.0",
+ "hmac-drbg",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
+ "rand 0.7.3",
+ "serde",
+ "sha2 0.9.9",
+ "typenum",
+]
+
+[[package]]
+name = "libsecp256k1-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f6ab710cec28cef759c5f18671a27dae2a5f952cdaaee1d8e2908cb2478a80"
+dependencies = [
+ "crunchy",
+ "digest 0.9.0",
+ "subtle",
+]
+
+[[package]]
+name = "libsecp256k1-gen-ecmult"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccab96b584d38fac86a83f07e659f0deafd0253dc096dab5a36d53efe653c5c3"
+dependencies = [
+ "libsecp256k1-core",
+]
+
+[[package]]
+name = "libsecp256k1-gen-genmult"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67abfe149395e3aa1c48a2beb32b068e2334402df8181f818d3aee2b304c4f5d"
+dependencies = [
+ "libsecp256k1-core",
+]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.10"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
@@ -1416,18 +1991,18 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg 1.2.0",
  "scopeguard",
 ]
 
 [[package]]
 name = "lockfree"
 version = "0.5.1"
-source = "git+https://github.com/tonlabs/lockfree.git#bfcb66587dc4ffed9e8e9248995ad2fe8dc3669e"
+source = "git+https://github.com/everx-labs/lockfree.git#bfcb66587dc4ffed9e8e9248995ad2fe8dc3669e"
 dependencies = [
  "owned-alloc",
 ]
@@ -1438,14 +2013,14 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 dependencies = [
- "log 0.4.20",
+ "log 0.4.21",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 dependencies = [
  "serde",
 ]
@@ -1458,9 +2033,9 @@ checksum = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
 
 [[package]]
 name = "log4rs"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d36ca1786d9e79b8193a68d480a0907b612f109537115c6ff655a3a1967533fd"
+checksum = "0816135ae15bd0391cf284eab37e6e3ee0a6ee63d2ceeb659862bd8d0a984ca6"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1469,9 +2044,11 @@ dependencies = [
  "fnv",
  "humantime",
  "libc",
- "log 0.4.20",
+ "log 0.4.21",
  "log-mdc",
- "parking_lot 0.12.1",
+ "once_cell",
+ "parking_lot 0.12.2",
+ "rand 0.8.5",
  "serde",
  "serde-value",
  "serde_json",
@@ -1480,6 +2057,15 @@ dependencies = [
  "thread-id",
  "typemap-ors",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "lru"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
+dependencies = [
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1496,9 +2082,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "memoffset"
@@ -1506,7 +2092,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg 1.2.0",
 ]
 
 [[package]]
@@ -1515,20 +2101,20 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde3af1a009ed76a778cb84fdef9e7dbbdf5775ae3e4cc1f434a6a307f6f76c5"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "metrics-macros",
  "portable-atomic",
 ]
 
 [[package]]
 name = "metrics-macros"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddece26afd34c31585c74a4db0630c376df271c285d682d1e55012197830b6df"
+checksum = "38b4faf00617defe497754acde3024865bc143d44a86799b24e191ecff91354f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1570,9 +2156,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
 ]
@@ -1589,7 +2175,7 @@ dependencies = [
  "iovec",
  "kernel32-sys",
  "libc",
- "log 0.4.20",
+ "log 0.4.21",
  "miow",
  "net2",
  "slab",
@@ -1598,13 +2184,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.9"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1633,7 +2219,7 @@ checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
 dependencies = [
  "lazy_static",
  "libc",
- "log 0.4.20",
+ "log 0.4.21",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -1656,9 +2242,9 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
+checksum = "3135b08af27d103b0a51f2ae0f8632117b7b185ccf931445affa8df530576a41"
 dependencies = [
  "num-bigint",
  "num-complex",
@@ -1674,19 +2260,25 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg 1.2.0",
  "num-integer",
  "num-traits",
 ]
 
 [[package]]
 name = "num-complex"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
+checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-derive"
@@ -1701,21 +2293,20 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg 1.1.0",
  "num-traits",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg 1.2.0",
  "num-integer",
  "num-traits",
 ]
@@ -1726,7 +2317,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg 1.2.0",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -1734,11 +2325,11 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg 1.2.0",
 ]
 
 [[package]]
@@ -1747,38 +2338,38 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
 [[package]]
 name = "object"
-version = "0.32.1"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.57"
+version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.5.0",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
@@ -1795,7 +2386,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1806,9 +2397,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.93"
+version = "0.9.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
 dependencies = [
  "cc",
  "libc",
@@ -1855,18 +2446,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
- "lock_api 0.4.11",
+ "lock_api 0.4.12",
  "parking_lot_core 0.8.6",
 ]
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
 dependencies = [
- "lock_api 0.4.11",
- "parking_lot_core 0.9.9",
+ "lock_api 0.4.12",
+ "parking_lot_core 0.9.10",
 ]
 
 [[package]]
@@ -1894,21 +2485,39 @@ dependencies = [
  "instant",
  "libc",
  "redox_syscall 0.2.16",
- "smallvec 1.11.1",
+ "smallvec 1.13.2",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.4.1",
- "smallvec 1.11.1",
- "windows-targets",
+ "redox_syscall 0.5.1",
+ "smallvec 1.13.2",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216eaa586a190f0a738f2f918511eecfa90f13295abec0e457cdebcceda80cbd"
+dependencies = [
+ "crypto-mac 0.8.0",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95f5254224e617595d2cc3cc73ff0a5eaf2637519e25f03388154e9378b6ffa"
+dependencies = [
+ "crypto-mac 0.11.1",
 ]
 
 [[package]]
@@ -1919,9 +2528,9 @@ checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "phf"
@@ -1964,9 +2573,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -1986,15 +2595,15 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.27"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "platforms"
-version = "3.1.2"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4503fa043bf02cee09a9582e9554b4c6403b2ef55e4612e96561d294419429f8"
+checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
 
 [[package]]
 name = "plugin"
@@ -2013,9 +2622,15 @@ checksum = "60f6ce597ecdcc9a098e7fddacb1065093a3d66446fa16c675e7e71d1b5c28e6"
 
 [[package]]
 name = "portable-atomic"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b559898e0b4931ed2d3b959ab0c2da4d99cc644c4b0b1a35b4d344027f474023"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2025,12 +2640,18 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
 name = "publicsuffix"
@@ -2039,14 +2660,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95b4ce31ff0a27d93c8de1849cf58162283752f065a90d508f1105fa6c9a213f"
 dependencies = [
  "idna 0.2.3",
- "url 2.4.1",
+ "url 2.5.0",
+]
+
+[[package]]
+name = "publicsuffix"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a8c1bda5ae1af7f99a2962e49df150414a43d62404644d98dd5c3a93d07457"
+dependencies = [
+ "idna 0.3.0",
+ "psl-types",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -2154,7 +2785,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.10",
+ "getrandom 0.2.14",
 ]
 
 [[package]]
@@ -2254,18 +2885,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2275,9 +2906,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2286,9 +2917,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "reqwest"
@@ -2298,22 +2929,22 @@ checksum = "f88643aea3c1343c804950d7bf983bd2067f5ab59db6d613a08e05572f2714ab"
 dependencies = [
  "base64 0.10.1",
  "bytes 0.4.12",
- "cookie",
- "cookie_store",
+ "cookie 0.12.0",
+ "cookie_store 0.7.0",
  "encoding_rs",
  "flate2",
  "futures 0.1.31",
  "http 0.1.21",
  "hyper 0.12.36",
- "hyper-tls",
- "log 0.4.20",
+ "hyper-tls 0.3.2",
+ "log 0.4.21",
  "mime 0.3.17",
  "mime_guess 2.0.4",
  "native-tls",
  "serde",
  "serde_json",
- "serde_urlencoded",
- "time",
+ "serde_urlencoded 0.5.5",
+ "time 0.1.45",
  "tokio 0.1.22",
  "tokio-executor",
  "tokio-io",
@@ -2321,7 +2952,49 @@ dependencies = [
  "tokio-timer",
  "url 1.7.2",
  "uuid",
- "winreg",
+ "winreg 0.6.2",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes 1.6.0",
+ "cookie 0.17.0",
+ "cookie_store 0.20.0",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
+ "hyper-tls 0.5.0",
+ "ipnet",
+ "js-sys",
+ "log 0.4.21",
+ "mime 0.3.17",
+ "native-tls",
+ "once_cell",
+ "percent-encoding 2.3.1",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded 0.7.1",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio 1.37.0",
+ "tokio-native-tls",
+ "tower-service",
+ "url 2.5.0",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.50.0",
 ]
 
 [[package]]
@@ -2348,6 +3021,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2362,27 +3041,36 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.20",
+ "semver 1.0.22",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.21"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.5.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "safemem"
@@ -2391,12 +3079,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
-name = "schannel"
-version = "0.1.22"
+name = "salsa20"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
+checksum = "ecbd2eb639fd7cab5804a0837fe373cc2172d15437e804c054a9fb885cb923b0"
 dependencies = [
- "windows-sys",
+ "cipher 0.3.0",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+dependencies = [
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2404,6 +3101,18 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879588d8f90906e73302547e20fffefdd240eb3e0e744e142321f5d49dea0518"
+dependencies = [
+ "hmac 0.11.0",
+ "pbkdf2 0.8.0",
+ "salsa20",
+ "sha2 0.9.9",
+]
 
 [[package]]
 name = "secstr"
@@ -2416,9 +3125,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.9.2"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -2429,9 +3138,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+checksum = "41f3cc463c0ef97e11c3461a9d3787412d30e8e7eb907c79180c4a57bf7c04ef"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2448,9 +3157,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "semver-parser"
@@ -2460,9 +3169,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.190"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
+checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
 dependencies = [
  "serde_derive",
 ]
@@ -2479,25 +3188,36 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.190"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
+checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
- "indexmap 2.0.2",
- "itoa 1.0.9",
+ "indexmap 2.2.6",
+ "itoa 1.0.11",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2513,15 +3233,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.8.26"
+name = "serde_urlencoded"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
- "indexmap 1.9.3",
+ "form_urlencoded",
+ "itoa 1.0.11",
  "ryu",
  "serde",
- "yaml-rust",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.2.6",
+ "itoa 1.0.11",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2556,15 +3300,18 @@ checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
 name = "signature"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
 
 [[package]]
 name = "similar"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aeaf503862c419d66959f5d7ca015337d864e9c49485d771b732e2a20453597"
+checksum = "fa42c91313f1d05da9b26f267f931cf178d4aba455b4c4622dd7355eb80c6640"
 dependencies = [
  "bstr 0.2.17",
 ]
@@ -2581,7 +3328,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg 1.2.0",
 ]
 
 [[package]]
@@ -2595,35 +3342,34 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
-name = "socket2"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+name = "sodalite"
+version = "0.3.0"
+source = "git+https://github.com/everx-labs/sodalite.git#667f7f01290c95fdbeadc5bce3e32c1d14b92fe1"
 dependencies = [
- "libc",
- "windows-sys",
+ "index-fixed",
+ "rand 0.7.3",
 ]
 
 [[package]]
 name = "spki"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
@@ -2646,9 +3392,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
@@ -2663,14 +3409,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "synstructure"
@@ -2685,51 +3437,71 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.8.1"
+name = "system-configuration"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
- "redox_syscall 0.4.1",
  "rustix",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "termcolor"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "textwrap"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2743,6 +3515,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
 name = "time"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2751,6 +3532,56 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "time"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+dependencies = [
+ "deranged",
+ "itoa 1.0.11",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tiny-bip39"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc59cb9dfc85bb312c3a78fd6aa8a8582e310b0fa885d5bb877f6dcc601839d"
+dependencies = [
+ "anyhow",
+ "hmac 0.8.1",
+ "once_cell",
+ "pbkdf2 0.4.0",
+ "rand 0.7.3",
+ "rustc-hash",
+ "sha2 0.9.9",
+ "thiserror",
+ "unicode-normalization",
+ "wasm-bindgen",
+ "zeroize",
 ]
 
 [[package]]
@@ -2789,18 +3620,19 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.33.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "libc",
- "mio 0.8.9",
+ "mio 0.8.11",
  "num_cpus",
  "pin-project-lite",
- "socket2 0.5.5",
- "windows-sys",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2842,7 +3674,28 @@ checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.31",
- "log 0.4.20",
+ "log 0.4.21",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio 1.37.0",
 ]
 
 [[package]]
@@ -2854,7 +3707,7 @@ dependencies = [
  "crossbeam-utils",
  "futures 0.1.31",
  "lazy_static",
- "log 0.4.20",
+ "log 0.4.21",
  "mio 0.6.23",
  "num_cpus",
  "parking_lot 0.9.0",
@@ -2866,13 +3719,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
 dependencies = [
  "futures-core",
  "pin-project-lite",
- "tokio 1.33.0",
+ "tokio 1.37.0",
 ]
 
 [[package]]
@@ -2910,7 +3763,7 @@ dependencies = [
  "crossbeam-utils",
  "futures 0.1.31",
  "lazy_static",
- "log 0.4.20",
+ "log 0.4.21",
  "num_cpus",
  "slab",
  "tokio-executor",
@@ -2929,45 +3782,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
+dependencies = [
+ "futures-util",
+ "log 0.4.21",
+ "native-tls",
+ "tokio 1.37.0",
+ "tokio-native-tls",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
 dependencies = [
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "futures-core",
  "futures-sink",
- "log 0.4.20",
+ "log 0.4.21",
  "pin-project-lite",
- "tokio 1.33.0",
+ "tokio 1.37.0",
 ]
 
 [[package]]
-name = "ton_abi"
-version = "2.3.147"
-source = "git+https://github.com/tonlabs/ever-abi.git?tag=2.3.147#a3194277b02417e4f01221f5cf6b943fc4bd6653"
+name = "tokio-util"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
- "base64 0.10.1",
- "byteorder",
- "chrono",
- "failure",
- "hex 0.3.2",
- "num-bigint",
- "num-traits",
- "serde",
- "serde_derive",
- "serde_json",
- "sha2 0.10.8",
- "ton_block",
- "ton_types",
+ "bytes 1.6.0",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio 1.37.0",
+ "tracing",
 ]
 
 [[package]]
 name = "ton_api"
-version = "0.3.41"
-source = "git+https://github.com/tonlabs/ever-tl.git?tag=0.3.41#deba4507ebca1bf8950907a2c9bc0938ac0016d8"
+version = "0.3.77"
+source = "git+https://github.com/everx-labs/ever-tl.git?tag=0.3.77#387f9b915a72c0a0b3a1c5b477e4dc29e1d2f0e7"
 dependencies = [
  "byteorder",
+ "ever_block 1.10.0",
  "extfmt",
  "failure",
  "hex 0.4.3",
@@ -2977,67 +3839,132 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "ton_block",
- "ton_tl_codegen",
- "ton_types",
+ "ton_tl_codegen 0.1.0 (git+https://github.com/everx-labs/ever-tl.git?tag=0.3.77)",
 ]
 
 [[package]]
-name = "ton_block"
-version = "1.9.104"
-source = "git+https://github.com/tonlabs/ever-block?tag=1.9.104#2c6cf392260d047cff5962572a628c207ea28309"
+name = "ton_api"
+version = "0.3.79"
+source = "git+https://github.com/everx-labs/ever-tl.git?tag=0.3.79#a204ea39dcb31a82d3f0ceece8e3c3ff85371a41"
 dependencies = [
- "base64 0.13.1",
- "crc 3.0.1",
- "ed25519 1.5.3",
- "ed25519-dalek 1.0.1",
- "failure",
- "hex 0.4.3",
- "log 0.4.20",
- "num",
- "num-traits",
- "sha2 0.10.8",
- "ton_types",
-]
-
-[[package]]
-name = "ton_block_json"
-version = "0.7.189"
-source = "git+https://github.com/tonlabs/ever-block-json?tag=0.7.189#3c9e31d18724e19c71cc09aaca37631060017ac5"
-dependencies = [
- "base64 0.13.1",
+ "byteorder",
+ "ever_block 1.10.2",
+ "extfmt",
  "failure",
  "hex 0.4.3",
  "lazy_static",
- "log 0.4.20",
- "metrics",
- "num",
+ "ordered-float",
+ "secstr",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "ton_tl_codegen 0.1.0 (git+https://github.com/everx-labs/ever-tl.git?tag=0.3.79)",
+]
+
+[[package]]
+name = "ton_client"
+version = "1.46.1"
+source = "git+https://github.com/everx-labs/ever-sdk.git?tag=1.46.1#ac13c266f8a8609b77cce31a21a0a76cc65fda47"
+dependencies = [
+ "aes",
+ "api_derive",
+ "api_info",
+ "async-trait",
+ "base58",
+ "base64 0.10.1",
+ "bincode",
+ "block-modes",
+ "byteorder",
+ "chacha20",
+ "chrono",
+ "crc 3.2.1",
+ "ed25519-dalek 2.1.1",
+ "ever-struct",
+ "ever_abi 2.5.1",
+ "ever_block 1.10.0",
+ "ever_block_json 0.8.3",
+ "ever_executor 1.17.3",
+ "ever_vm 2.1.2",
+ "failure",
+ "futures 0.3.30",
+ "hex 0.3.2",
+ "hmac 0.11.0",
+ "home",
+ "lazy_static",
+ "libsecp256k1",
+ "lockfree",
+ "log 0.4.21",
+ "lru",
+ "num-bigint",
+ "num-derive",
+ "num-traits",
+ "pbkdf2 0.8.0",
+ "rand 0.7.3",
+ "regex",
+ "reqwest 0.11.27",
+ "scrypt",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "sha2 0.9.9",
+ "sodalite",
+ "tiny-bip39",
+ "tokio 1.37.0",
+ "tokio-stream",
+ "tokio-tungstenite",
+ "ton_client_processing",
+ "ton_sdk",
+ "zeroize",
+ "zstd",
+]
+
+[[package]]
+name = "ton_client_processing"
+version = "1.46.1"
+source = "git+https://github.com/everx-labs/ever-sdk.git?tag=1.46.1#ac13c266f8a8609b77cce31a21a0a76cc65fda47"
+dependencies = [
+ "api_derive",
+ "api_info",
+ "async-trait",
+ "base64 0.21.7",
+ "ever_block 1.10.0",
+ "futures 0.3.30",
+ "log 0.4.21",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "tokio 1.37.0",
+]
+
+[[package]]
+name = "ton_sdk"
+version = "1.46.1"
+source = "git+https://github.com/everx-labs/ever-sdk.git?tag=1.46.1#ac13c266f8a8609b77cce31a21a0a76cc65fda47"
+dependencies = [
+ "api_derive",
+ "api_info",
+ "base64 0.10.1",
+ "chrono",
+ "ever_abi 2.5.1",
+ "ever_block 1.10.0",
+ "failure",
+ "hex 0.3.2",
+ "lazy_static",
+ "log 0.4.21",
+ "num-bigint",
  "num-traits",
  "serde",
  "serde_derive",
  "serde_json",
- "ton_api",
- "ton_block",
- "ton_types",
-]
-
-[[package]]
-name = "ton_executor"
-version = "1.16.82"
-source = "git+https://github.com/tonlabs/ever-executor?tag=1.16.82#338d0c7aa64d6239ace031541f9c768bb25827a8"
-dependencies = [
- "failure",
- "lazy_static",
- "log 0.4.20",
- "ton_block",
- "ton_types",
- "ton_vm",
+ "sha2 0.9.9",
 ]
 
 [[package]]
 name = "ton_tl_codegen"
 version = "0.1.0"
-source = "git+https://github.com/tonlabs/ever-tl.git?tag=0.3.41#deba4507ebca1bf8950907a2c9bc0938ac0016d8"
+source = "git+https://github.com/everx-labs/ever-tl.git?tag=0.3.77#387f9b915a72c0a0b3a1c5b477e4dc29e1d2f0e7"
 dependencies = [
  "crc 1.8.1",
  "failure",
@@ -3050,51 +3977,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "ton_types"
-version = "2.0.28"
-source = "git+https://github.com/tonlabs/ever-types?tag=2.0.28#e6ce975e741634638e4d42f4e8b273ea4d046370"
+name = "ton_tl_codegen"
+version = "0.1.0"
+source = "git+https://github.com/everx-labs/ever-tl.git?tag=0.3.79#a204ea39dcb31a82d3f0ceece8e3c3ff85371a41"
 dependencies = [
- "aes-ctr",
- "base64 0.13.1",
- "crc 3.0.1",
- "curve25519-dalek 4.1.1",
- "ed25519 2.2.3",
- "ed25519-dalek 2.0.0",
+ "crc 1.8.1",
  "failure",
- "hex 0.4.3",
- "lazy_static",
- "lockfree",
- "log 0.4.20",
- "num",
- "num-derive",
- "num-traits",
- "rand 0.8.5",
+ "pom",
+ "proc-macro2",
+ "quote",
  "serde",
- "serde_json",
- "sha2 0.10.8",
- "smallvec 1.11.1",
- "x25519-dalek",
-]
-
-[[package]]
-name = "ton_vm"
-version = "1.8.211"
-source = "git+https://github.com/tonlabs/ever-vm?tag=1.8.211#ca3e6e70793a86ec20d27d1463030ca864bf1f59"
-dependencies = [
- "diffy",
- "ed25519 1.5.3",
- "ed25519-dalek 1.0.1",
- "failure",
- "hex 0.4.3",
- "lazy_static",
- "log 0.4.20",
- "num",
- "num-traits",
- "rand 0.7.3",
- "similar",
- "ton_block",
- "ton_types",
- "zstd",
+ "serde_derive",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3130,9 +4024,9 @@ checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 
 [[package]]
 name = "try-lock"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "try_from"
@@ -3141,6 +4035,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b"
 dependencies = [
  "cfg-if 0.1.10",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
+dependencies = [
+ "base64 0.13.1",
+ "byteorder",
+ "bytes 1.6.0",
+ "http 0.2.12",
+ "httparse",
+ "log 0.4.21",
+ "native-tls",
+ "rand 0.8.5",
+ "sha-1",
+ "thiserror",
+ "url 2.5.0",
+ "utf-8",
 ]
 
 [[package]]
@@ -3193,9 +4107,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
@@ -3205,9 +4119,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
@@ -3237,6 +4151,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "url"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3249,14 +4169,20 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
- "idna 0.4.0",
- "percent-encoding 2.3.0",
+ "idna 0.5.0",
+ "percent-encoding 2.3.1",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "uuid"
@@ -3292,7 +4218,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
 dependencies = [
  "futures 0.1.31",
- "log 0.4.20",
+ "log 0.4.21",
  "try-lock",
 ]
 
@@ -3325,9 +4251,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -3335,24 +4261,36 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
- "log 0.4.20",
+ "log 0.4.21",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.60",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.87"
+name = "wasm-bindgen-futures"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3360,22 +4298,32 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.60",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+
+[[package]]
+name = "web-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"
@@ -3407,11 +4355,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "winapi 0.3.9",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3422,11 +4370,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.51.1"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -3435,7 +4383,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -3444,13 +4401,29 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
 
 [[package]]
@@ -3460,10 +4433,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3472,10 +4457,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3484,10 +4487,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3496,12 +4511,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
 name = "winreg"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
 dependencies = [
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3516,50 +4547,41 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb66477291e7e8d2b0ff1bcb900bf29489a9692816d79874bea351e7a8b6de96"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
- "curve25519-dalek 4.1.1",
+ "curve25519-dalek 4.1.2",
  "rand_core 0.6.4",
  "serde",
  "zeroize",
 ]
 
 [[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
-]
-
-[[package]]
 name = "zerocopy"
-version = "0.7.15"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ba595b9f2772fbee2312de30eeb80ec773b4cb2f1e8098db024afadda6c06f"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.15"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772666c41fb6dceaf520b564b962d738a8e1a83b41bd48945f50837aed78bb1d"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 dependencies = [
  "zeroize_derive",
 ]
@@ -3572,7 +4594,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3596,9 +4618,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.9+zstd.1.5.5"
+version = "2.0.10+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
+checksum = "c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa"
 dependencies = [
  "cc",
  "pkg-config",

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Local Node with GraphQL API for DApp development and testing in TVM compatible b
 Evernode Simple Emulator (SE) is a local instance of Evernode Platform that developer can run on their machine in one click to test applications locally. 
 
 At the moment we publish Evernode SE only as
-a [docker image](https://hub.docker.com/r/tonlabs/local-node).
+a [docker image](https://hub.docker.com/r/everx-labs/local-node).
 But you can access non-docker builds of SE in community repos:
 
 ## Use-cases
@@ -52,7 +52,7 @@ But you can access non-docker builds of SE in community repos:
 
 ### Install via EVERDEV Development Environment
 
-If you have [EVERDEV installed globally on your machine](https://github.com/tonlabs/everdev), run
+If you have [EVERDEV installed globally on your machine](https://github.com/everx-labs/everdev), run
 this command
 
 ```commandline
@@ -171,7 +171,7 @@ application specify [SE endpoints](https://docs.evercloud.dev/products/simple-em
 
 ## Evernode SE components
 
-* [EverX implementation of TON VM written in Rust](https://github.com/tonlabs/ever-vm)
+* [EverX implementation of TON VM written in Rust](https://github.com/everx-labs/ever-vm)
 * [ArangoDB database](https://www.arangodb.com/)
 * [GraphQL endpoint with web playground](https://docs.evercloud.dev/reference/graphql-api)
 * [Ever.live blockchain explorer](https://ever.live)
@@ -253,9 +253,9 @@ inside this folder to prepare dev tools).
 If you want to debug SE without docker you have to run evernode-se with following additional
 components:
 
-- Q Server (required to communicate with [ever-sdk](https://github.com/tonlabs/ever-sdk)):
-    - Checkout `ton-q-server` from [official repository](https://github.com/tonlabs/ton-q-server).
-    - Inside `ton-q-server` folder run:
+- Q Server (required to communicate with [ever-sdk](https://github.com/everx-labs/ever-sdk)):
+    - Checkout `ever-q-server` from [official repository](https://github.com/everx-labs/ever-q-server).
+    - Inside `ever-q-server` folder run:
         ```commandline
         npm i
         ```
@@ -264,7 +264,7 @@ components:
         node path-to-q-server/index --config ./dev/q-server.json
         ```
 
-- Arango DB (required to `ton-q-server`):
+- Arango DB (required to `ever-q-server`):
     - Download and install from [official site](https://www.arangodb.com/download-major).
     - Start Arango DB Server.
     - For the first time or if you want to reset database to initial state run:

--- a/build.cmd
+++ b/build.cmd
@@ -5,7 +5,7 @@ set TONOS_SE="tonlabs/evernode-se"
 
 set BIN_TARGET="evernode_se"
 
-set Q_SERVER_GITHUB_REPO="https://github.com/tonlabs/ton-q-server"
+set Q_SERVER_GITHUB_REPO="https://github.com/everx-labs/ever-q-server"
 set /P Q_SERVER_GITHUB_REV=<q-server.version
 
 echo.

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ TONOS_SE="${TONOS_SE:-tonlabs/evernode-se}"
 
 BIN_TARGET="evernode_se"
 
-Q_SERVER_GITHUB_REPO="https://github.com/tonlabs/ton-q-server"
+Q_SERVER_GITHUB_REPO="https://github.com/everx-labs/ever-q-server"
 Q_SERVER_GITHUB_REV="${Q_SERVER_GITHUB_REV:-$(cat q-server.version)}"
 
 echo

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update && apt-get install git
 # Install Q-Server
 USER node
 WORKDIR /home/node
-RUN git clone --recursive --branch $Q_SERVER_GITHUB_REV $Q_SERVER_GITHUB_REPO ton-q-server
-WORKDIR /home/node/ton-q-server
+RUN git clone --recursive --branch $Q_SERVER_GITHUB_REV $Q_SERVER_GITHUB_REPO ever-q-server
+WORKDIR /home/node/ever-q-server
 RUN npm ci; \
     npm run tsc; \
     npm ci --production

--- a/docker/q-server/entrypoint
+++ b/docker/q-server/entrypoint
@@ -11,5 +11,5 @@ export Q_QUERY_WAIT_FOR_PERIOD=10
 export Q_CHAIN_RANGES_VERIFICATION=http://127.0.0.1:8529
 export Q_SLOW_QUERIES=enable
 
-cd /home/node/ton-q-server
+cd /home/node/ever-q-server
 exec node index.js

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -14,7 +14,6 @@ serde_json = "1.0.57"
 tokio = { version = "1.19", features = ["rt-multi-thread"] }
 reqwest = "0.11.11"
 
-ton_block = { git = "https://github.com/tonlabs/ever-block.git", tag = "1.9.104" }
-ton_client = { git = 'https://github.com/tonlabs/ever-sdk.git', package = "ton_client", tag = "1.44.3" }
-ton_types = { git = "https://github.com/tonlabs/ever-types.git", tag = "2.0.28" }
+ever_block = { git = "https://github.com/everx-labs/ever-block.git", tag = "1.10.2" }
+ton_client = { git = 'https://github.com/everx-labs/ever-sdk.git', package = "ton_client", tag = "1.46.1" }
 

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -8,10 +8,16 @@ use std::time::Duration;
 use failure::err_msg;
 use lazy_static::lazy_static;
 use serde_json::{json, Value};
-use ton_block::{BlockProcessingStatus, MessageProcessingStatus, TransactionProcessingStatus, Serializable};
+use ever_block::{
+    BlockProcessingStatus,
+    MessageProcessingStatus,
+    TransactionProcessingStatus,
+    Serializable,
+    Result
+};
 use ton_client::abi::{
     encode_message, Abi, CallSet, DeploySet, FunctionHeader, ParamsOfEncodeMessage,
-    ResultOfEncodeMessage, Signer,
+    ResultOfEncodeMessage, Signer
 };
 use ton_client::boc::{parse_message, ParamsOfParse};
 use ton_client::crypto::KeyPair;
@@ -25,7 +31,6 @@ use ton_client::processing::{
 use ton_client::processing::{ParamsOfSendMessage, ParamsOfWaitForTransaction};
 use ton_client::tvm::{run_tvm, ParamsOfRunTvm, ResultOfRunTvm};
 use ton_client::{ClientConfig, ClientContext};
-use ton_types::Result;
 
 const DEFAULT_NETWORK_ADDRESS: &str = "http://localhost";
 type Keypair = ed25519_dalek::Keypair;
@@ -1044,11 +1049,13 @@ async fn test_bounced_body() {
                     components: vec![],
                     name: "a".to_owned(),
                     param_type: "uint256".to_owned(),
+                    ..Default::default()
                 },
                 ton_client::abi::AbiParam {
                     components: vec![],
                     name: "b".to_owned(),
                     param_type: "uint32".to_owned(),
+                    ..Default::default()
                 }
             ],
             data: json!({
@@ -1097,11 +1104,13 @@ async fn test_bounced_body() {
                     components: vec![],
                     name: "a".to_owned(),
                     param_type: "int32".to_owned(),
+                    ..Default::default()
                 },
                 ton_client::abi::AbiParam {
                     components: vec![],
                     name: "b".to_owned(),
                     param_type: "uint256".to_owned(),
+                    ..Default::default()
                 },
                 ton_client::abi::AbiParam {
                     name: "c".to_owned(),
@@ -1111,13 +1120,16 @@ async fn test_bounced_body() {
                             components: vec![],
                             name: "a".to_owned(),
                             param_type: "uint256".to_owned(),
+                            ..Default::default()
                         },
                         ton_client::abi::AbiParam {
                             components: vec![],
                             name: "b".to_owned(),
                             param_type: "uint32".to_owned(),
+                            ..Default::default()
                         }
                     ],
+                    ..Default::default()
                 },
             ],
             data: json!({
@@ -1315,7 +1327,7 @@ async fn test_fork() {
 
     let send_msg = || async move {
         let client = Client::new();
-        let msg = ton_block::Message::with_ext_in_header(ton_block::ExternalInboundMessageHeader { 
+        let msg = ever_block::Message::with_ext_in_header(ever_block::ExternalInboundMessageHeader { 
             src: Default::default(),
             dst: "-1:0000000000000000000000000000000000000000000000000000000000000000".parse().unwrap(),
             import_fee: Default::default(),

--- a/memory/entrypoint
+++ b/memory/entrypoint
@@ -13,5 +13,5 @@ export Q_PORT=4000
 export Q_QUERY_WAIT_FOR_PERIOD=10
 export Q_CHAIN_RANGES_VERIFICATION=http://127.0.0.1:8529
 
-cd /home/node/ton-q-server
+cd /home/node/ever-q-server
 exec node --max-old-space-size=200 index.js 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -2,7 +2,7 @@
 edition = '2021'
 build = 'build.rs'
 name = 'evernode_se'
-version = '0.40.0'
+version = '0.41.0'
 
 [dependencies]
 # External
@@ -29,21 +29,19 @@ serde_derive = '1.0'
 serde_json = { features = ['preserve_order'], version = '1.0' }
 thiserror = '1.0'
 
-lockfree = { git = 'https://github.com/tonlabs/lockfree.git', package = 'lockfree' }
+lockfree = { git = 'https://github.com/everx-labs/lockfree.git', package = 'lockfree' }
 
 # Domestic
-ton_block = { git = 'https://github.com/tonlabs/ever-block', tag = '1.9.104' }
-ton_block_json = { git = 'https://github.com/tonlabs/ever-block-json', tag = '0.7.189' }
-ton_executor = { git = 'https://github.com/tonlabs/ever-executor', tag = '1.16.82', features = ['signature_with_id'] }
-ton_types = { git = 'https://github.com/tonlabs/ever-types', tag = '2.0.28' }
-ton_vm = { git = 'https://github.com/tonlabs/ever-vm', tag = '1.8.211', features = ['gosh'] }
+ever_block = { git = 'https://github.com/everx-labs/ever-block', tag = '1.10.2' }
+ever_block_json = { git = 'https://github.com/everx-labs/ever-block-json', tag = '0.8.6' }
+ever_executor = { git = 'https://github.com/everx-labs/ever-executor', tag = '1.17.6', features = ['signature_with_id'] }
+ever_vm = { git = 'https://github.com/everx-labs/ever-vm', tag = '2.1.5', features = ['gosh'] }
 
-#ton_block = { path = '../../ever-block-private' }
-#ton_block_json = { path = '../../ever-block-json-private' }
-#ton_executor = { path = '../../ever-executor-private', features = ['signature_with_id'] }
-#ton_types = { path = '../../ever-types-private' }
-#ton_vm = { path = '../../ever-vm-private', features = ['gosh'] }
+#ever_block = { path = '../../ever-block-private' }
+#ever_block_json = { path = '../../ever-block-json-private' }
+#ever_executor = { path = '../../ever-executor-private', features = ['signature_with_id'] }
+#ever_vm = { path = '../../ever-vm-private', features = ['gosh'] }
 
 [dev-dependencies]
-ton_abi = { git = 'https://github.com/tonlabs/ever-abi.git', tag = '2.3.147' }
-#ton_abi = { path = '../../ever-abi' }
+ever_abi = { git = 'https://github.com/everx-labs/ever-abi.git', tag = '2.5.3' }
+#ever_abi = { path = '../../ever-abi' }

--- a/node/config/log_cfg.yml
+++ b/node/config/log_cfg.yml
@@ -39,7 +39,7 @@ loggers:
       - stdout
 
   # block messages
-  ton_block:
+  ever_block:
     level: debug
     appenders:
       - stdout

--- a/node/src/block/builder.rs
+++ b/node/src/block/builder.rs
@@ -22,19 +22,19 @@ use std::ops::Deref;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use serde_derive::Serialize;
-use ton_block::{
+use ever_block::{
     Account, AddSub, Augmentation, BlkPrevInfo, Block, BlockExtra, BlockInfo, ComputeSkipReason,
     CopyleftRewards, CurrencyCollection, Deserializable, EnqueuedMsg, HashUpdate, HashmapAugType,
     InMsg, InMsgDescr, MerkleUpdate, Message, MsgEnvelope, OutMsg, OutMsgDescr, OutMsgQueue,
     OutMsgQueueInfo, OutMsgQueueKey, Serializable, ShardAccount, ShardAccountBlocks, ShardAccounts,
     ShardIdent, ShardStateUnsplit, TrComputePhase, TrComputePhaseVm, Transaction, TransactionDescr,
-    TransactionDescrOrdinary, UnixTime32, ValueFlow,
+    TransactionDescrOrdinary, UnixTime32, ValueFlow,error, AccountId, Cell, HashmapRemover, HashmapType,
+    Result, SliceData, UInt256
 };
-use ton_executor::{
+use ever_executor::{
     BlockchainConfig, ExecuteParams, ExecutorError, OrdinaryTransactionExecutor,
     TransactionExecutor,
 };
-use ton_types::{error, AccountId, Cell, HashmapRemover, HashmapType, Result, SliceData, UInt256};
 
 use crate::error::NodeResult;
 
@@ -60,8 +60,8 @@ pub struct EngineTraceInfoData {
     pub cmd_code_offset: u32,
 }
 
-impl From<&ton_vm::executor::EngineTraceInfo<'_>> for EngineTraceInfoData {
-    fn from(info: &ton_vm::executor::EngineTraceInfo) -> Self {
+impl From<&ever_vm::executor::EngineTraceInfo<'_>> for EngineTraceInfoData {
+    fn from(info: &ever_vm::executor::EngineTraceInfo) -> Self {
         let cmd_code_rem_bits = info.cmd_code.remaining_bits() as u32;
         let cmd_code_hex = info.cmd_code.to_hex_string();
         let cmd_code_cell_hash = info.cmd_code.cell().repr_hash().to_hex_string();
@@ -176,9 +176,9 @@ impl BlockBuilder {
 
         let trace = Arc::new(lockfree::queue::Queue::new());
         let trace_copy = trace.clone();
-        let callback = move |engine: &ton_vm::executor::Engine, info: &ton_vm::executor::EngineTraceInfo| {
+        let callback = move |engine: &ever_vm::executor::Engine, info: &ever_vm::executor::EngineTraceInfo| {
             trace_copy.push(EngineTraceInfoData::from(info));
-            ton_vm::executor::Engine::simple_trace_callback(engine, info);
+            ever_vm::executor::Engine::simple_trace_callback(engine, info);
         };
 
         let start = std::time::Instant::now();
@@ -275,7 +275,7 @@ impl BlockBuilder {
             None => self.accounts_provider
                 .as_ref()
                 .map(|provider| provider.get_account(
-                ton_block::MsgAddressInt::with_standart(
+                ever_block::MsgAddressInt::with_standart(
                     None, self.shard_ident().workchain_id() as i8, acc_id.clone()
                 )?))
                 .transpose()?

--- a/node/src/block/finality.rs
+++ b/node/src/block/finality.rs
@@ -22,12 +22,11 @@ use crate::error::NodeError;
 use crate::NodeResult;
 use std::io::{Cursor, ErrorKind, Read, Seek, Write};
 use std::{collections::HashMap, sync::Arc};
-use ton_block::{
+use ever_block::{
     Account, BlkPrevInfo, Block, Deserializable, ExtBlkRef, Serializable, ShardIdent,
-    ShardStateUnsplit,
+    ShardStateUnsplit, ByteOrderRead, HashmapType, UInt256
 };
-use ton_block_json::{BlockParser, BlockParserConfig, EntryConfig, NoReduce, NoTrace};
-use ton_types::{ByteOrderRead, HashmapType, UInt256};
+use ever_block_json::{BlockParser, BlockParserConfig, EntryConfig, NoReduce, NoTrace};
 
 use super::builder::EngineTraceInfoData;
 

--- a/node/src/block/finality_block.rs
+++ b/node/src/block/finality_block.rs
@@ -2,8 +2,10 @@ use crate::error::NodeResult;
 use std::collections::HashMap;
 use std::io::{Read, Seek};
 use std::sync::Arc;
-use ton_block::{Block, Deserializable, Serializable, ShardIdent, ShardStateUnsplit};
-use ton_types::{ByteOrderRead, SliceData, UInt256};
+use ever_block::{
+    Block, Deserializable, Serializable, ShardIdent, ShardStateUnsplit,
+    ByteOrderRead, SliceData, UInt256
+};
 
 use super::builder::EngineTraceInfoData;
 
@@ -89,7 +91,7 @@ impl ShardBlock {
         let cell = block.serialize().unwrap();
         let root_hash = cell.repr_hash();
 
-        let serialized_block = ton_types::write_boc(&cell).unwrap();
+        let serialized_block = ever_block::write_boc(&cell).unwrap();
         let file_hash = UInt256::calc_file_hash(&serialized_block);
         let info = block.read_info().unwrap();
 
@@ -135,12 +137,15 @@ impl ShardBlock {
         let hash = rdr.read_u256()?;
         sb.file_hash = UInt256::from(hash);
 
-        let boc_reader = ton_types::BocReader::new();
-        let mut shard_slice = SliceData::load_cell(boc_reader.read(rdr)?.withdraw_single_root()?)?;
+        let mut shard_slice = SliceData::load_cell(
+            ever_block::BocReader::new().read(rdr)?.withdraw_single_root()?
+        )?;
+        
         sb.shard_state.read_from(&mut shard_slice)?;
 
-        let boc_reader = ton_types::BocReader::new();
-        sb.block = Block::construct_from_cell(boc_reader.read(rdr)?.withdraw_single_root()?)?;
+        sb.block = Block::construct_from_cell(
+            ever_block::BocReader::new().read(rdr)?.withdraw_single_root()?
+        )?;
         Ok(sb)
     }
 }

--- a/node/src/block/json.rs
+++ b/node/src/block/json.rs
@@ -4,9 +4,11 @@ use serde_json::Value;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Instant;
-use ton_block::{Account, BlockIdExt, MsgAddrStd, MsgAddressInt, Serializable};
-use ton_block_json::{BlockParser, NoReduce, NoTrace, ParsedEntry, ParsingBlock};
-use ton_types::{read_single_root_boc, Result, UInt256};
+use ever_block::{
+    Account, BlockIdExt, MsgAddrStd, MsgAddressInt, Serializable,
+    read_single_root_boc, Result, UInt256
+};
+use ever_block_json::{BlockParser, NoReduce, NoTrace, ParsedEntry, ParsingBlock};
 
 lazy_static::lazy_static!(
     static ref ACCOUNT_NONE_HASH: UInt256 = Account::default().serialize().unwrap().repr_hash();

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -24,8 +24,8 @@ pub struct ShardIdConfig {
 }
 
 impl ShardIdConfig {
-    pub fn shard_ident(&self) -> ton_block::ShardIdent {
-        ton_block::ShardIdent::with_prefix_len(
+    pub fn shard_ident(&self) -> ever_block::ShardIdent {
+        ever_block::ShardIdent::with_prefix_len(
             self.shardchain_pfx_len as u8,
             self.workchain,
             self.shardchain_pfx as u64,

--- a/node/src/data/fork_provider.rs
+++ b/node/src/data/fork_provider.rs
@@ -1,5 +1,5 @@
-use ton_block::Deserializable;
-use ton_executor::BlockchainConfig;
+use ever_block::Deserializable;
+use ever_executor::BlockchainConfig;
 
 use crate::{error::{NodeError, NodeResult}, config::ForkConfig};
 
@@ -72,7 +72,7 @@ impl ForkProvider {
             .flatten()
             .ok_or_else(|| NodeError::ForkEndpointFetchError("No key block found".to_owned()))?;
         
-        let block = ton_block::Block::construct_from_base64(boc)
+        let block = ever_block::Block::construct_from_base64(boc)
             .map_err(|err| NodeError::ForkEndpointFetchError(err.to_string()))?;
 
         let mc_extra = block
@@ -95,8 +95,8 @@ impl ForkProvider {
 impl ExternalAccountsProvider for ForkProvider {
     fn get_account(
         &self,
-        address: ton_block::MsgAddressInt,
-    ) -> NodeResult<Option<ton_block::ShardAccount>> {
+        address: ever_block::MsgAddressInt,
+    ) -> NodeResult<Option<ever_block::ShardAccount>> {
         let response = self.query(
             "query account($address:String!){blockchain{account(address:$address){info{boc}}}}",
             serde_json::json!({
@@ -112,11 +112,11 @@ impl ExternalAccountsProvider for ForkProvider {
             Some(boc) => {
                 let bytes = base64::decode(boc)
                     .map_err(|err| NodeError::ForkEndpointFetchError(err.to_string()))?;
-                let cell = ton_types::read_single_root_boc(&bytes)
+                let cell = ever_block::read_single_root_boc(&bytes)
                     .map_err(|err| NodeError::ForkEndpointFetchError(err.to_string()))?;
-                Ok(Some(ton_block::ShardAccount::with_account_root(
+                Ok(Some(ever_block::ShardAccount::with_account_root(
                     cell,
-                    ton_types::UInt256::default(),
+                    ever_block::UInt256::default(),
                     0,
                 )))
             }
@@ -136,7 +136,7 @@ fn test_account_provider() {
 
     dbg!(provider
         .get_account(
-            ton_block::MsgAddressInt::with_standart(None, -1, ton_types::UInt256::default().into())
+            ever_block::MsgAddressInt::with_standart(None, -1, ever_block::UInt256::default().into())
                 .unwrap()
         )
         .unwrap());

--- a/node/src/data/fs_storage.rs
+++ b/node/src/data/fs_storage.rs
@@ -21,7 +21,7 @@ use std::clone::Clone;
 use std::fs::{create_dir_all, File};
 use std::io::prelude::*;
 use std::path::PathBuf;
-use ton_block::ShardIdent;
+use ever_block::ShardIdent;
 
 ///
 /// Shard Storage based on file system

--- a/node/src/data/mem_storage.rs
+++ b/node/src/data/mem_storage.rs
@@ -1,7 +1,7 @@
 use crate::data::{shard_storage_key, KVStorage, NodeStorage};
 use crate::error::{NodeError, NodeResult};
 use std::collections::HashMap;
-use ton_block::ShardIdent;
+use ever_block::ShardIdent;
 
 pub struct MemStorage {
     zerostate: Vec<u8>,

--- a/node/src/data/mod.rs
+++ b/node/src/data/mod.rs
@@ -1,5 +1,5 @@
 use crate::NodeResult;
-use ton_block::ShardIdent;
+use ever_block::ShardIdent;
 
 mod fork_provider;
 mod arango;
@@ -16,9 +16,8 @@ pub use shard_storage::{shard_storage_key, ShardStorage, ShardStateInfo};
 pub use fork_provider::ForkProvider;
 
 #[cfg(test)]
-pub use documents_db_mock::DocumentsDbMock;
-
 pub use fs_storage::FSKVStorage;
+
 pub use mem_documents_db::MemDocumentsDb;
 
 pub trait NodeStorage {
@@ -46,5 +45,5 @@ pub trait DocumentsDb: Send + Sync {
 
 
 pub trait ExternalAccountsProvider: Send + Sync {
-    fn get_account(&self, address: ton_block::MsgAddressInt) -> NodeResult<Option<ton_block::ShardAccount>>;
+    fn get_account(&self, address: ever_block::MsgAddressInt) -> NodeResult<Option<ever_block::ShardAccount>>;
 }

--- a/node/src/data/shard_storage.rs
+++ b/node/src/data/shard_storage.rs
@@ -2,8 +2,7 @@ use crate::data::KVStorage;
 use crate::error::NodeResult;
 use std::cmp::Ordering;
 use std::sync::Mutex;
-use ton_block::{Block, Serializable, ShardStateUnsplit};
-use ton_types::UInt256;
+use ever_block::{Block, Serializable, ShardStateUnsplit, UInt256};
 
 ///
 /// Hash of ShardState with block sequence number
@@ -141,7 +140,7 @@ impl ShardStorage {
 }
 
 pub mod shard_storage_key {
-    use ton_types::UInt256;
+    use ever_block::UInt256;
 
     // ROOT
     pub const BLOCKS_FINALITY_INFO_KEY: &'static str = "blocks_finality.info";

--- a/node/src/engine/engine.rs
+++ b/node/src/engine/engine.rs
@@ -25,8 +25,8 @@ use crate::engine::BlockTimeMode;
 use crate::error::{NodeError, NodeResult};
 use parking_lot::RwLock;
 use std::sync::Arc;
-use ton_block::{Message, ShardIdent};
-use ton_executor::BlockchainConfig;
+use ever_block::{Message, ShardIdent};
+use ever_executor::BlockchainConfig;
 
 /// It is top level struct provided node functionality related to transactions processing.
 /// Initialises instances of: all messages receivers, InMessagesQueue, MessagesProcessor.

--- a/node/src/engine/masterchain.rs
+++ b/node/src/engine/masterchain.rs
@@ -6,11 +6,11 @@ use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use ton_block::{
+use ever_block::{
     BinTree, BinTreeType, Block, InRefValue, McBlockExtra, Serializable, ShardDescr, ShardIdent,
+    write_boc, SliceData, UInt256
 };
-use ton_executor::BlockchainConfig;
-use ton_types::{write_boc, SliceData, UInt256};
+use ever_executor::BlockchainConfig;
 
 pub struct Masterchain {
     blockchain_config: Arc<BlockchainConfig>,

--- a/node/src/engine/messages.rs
+++ b/node/src/engine/messages.rs
@@ -16,7 +16,7 @@
 
 use parking_lot::{Condvar, Mutex};
 use std::collections::VecDeque;
-use ton_block::{Message, Serializable};
+use ever_block::{Message, Serializable};
 
 /// This FIFO accumulates inbound messages from all types of receivers.
 /// The struct might be used from many threads. It provides internal mutability.
@@ -71,7 +71,7 @@ impl InMessagesQueue {
     pub fn print_message(msg: &Message) {
         log::info!("message: {:?}", msg);
         if let Ok(cell) = msg.serialize() {
-            if let Ok(data) = ton_types::write_boc(&cell) {
+            if let Ok(data) = ever_block::write_boc(&cell) {
                 std::fs::create_dir_all("export").ok();
                 std::fs::write(&format!("export/msg_{:x}", cell.repr_hash()), &data).ok();
             }

--- a/node/src/engine/shardchain.rs
+++ b/node/src/engine/shardchain.rs
@@ -6,9 +6,8 @@ use crate::error::NodeResult;
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::sync::Arc;
-use ton_block::{Block, ShardIdent, ShardStateUnsplit};
-use ton_executor::BlockchainConfig;
-use ton_types::{HashmapType, UInt256};
+use ever_block::{Block, ShardIdent, ShardStateUnsplit, HashmapType, UInt256};
+use ever_executor::BlockchainConfig;
 
 pub struct Shardchain {
     pub(crate) finality_was_loaded: bool,

--- a/node/src/engine/time.rs
+++ b/node/src/engine/time.rs
@@ -1,4 +1,4 @@
-use ton_block::UnixTime32;
+use ever_block::UnixTime32;
 
 #[derive(Copy, Clone, Debug)]
 pub enum BlockTimeMode {

--- a/node/src/error.rs
+++ b/node/src/error.rs
@@ -23,7 +23,7 @@ pub enum NodeError {
     #[error("Failure error: {0}")]
     FailureError(failure::Error),
     #[error("Block error: {0}")]
-    BlockError(ton_block::BlockError),
+    BlockError(ever_block::BlockError),
     #[error("Requested item not found")]
     NotFound,
     #[error("Database problem")]

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -22,7 +22,7 @@ use crate::service::{TonNodeService, TonNodeServiceConfig};
 use clap::{Arg, ArgMatches, Command};
 use serde_json::Value;
 use std::{env, fs, path::Path};
-use ton_executor::BlockchainConfig;
+use ever_executor::BlockchainConfig;
 
 pub mod error;
 
@@ -148,8 +148,8 @@ fn parse_config(json: &str) -> NodeConfig {
     }
 }
 
-fn blockchain_config_from_json(json: &str) -> ton_types::Result<BlockchainConfig> {
+fn blockchain_config_from_json(json: &str) -> ever_block::Result<BlockchainConfig> {
     let map = serde_json::from_str::<serde_json::Map<String, Value>>(&json)?;
-    let config_params = ton_block_json::parse_config(&map)?;
+    let config_params = ever_block_json::parse_config(&map)?;
     BlockchainConfig::with_config(config_params)
 }

--- a/node/src/service/engine_manager.rs
+++ b/node/src/service/engine_manager.rs
@@ -3,7 +3,7 @@ use crate::data::{ArangoHelper, ExternalAccountsProvider, FSStorage, ForkProvide
 use crate::engine::engine::TonNodeEngine;
 use crate::error::NodeResult;
 use parking_lot::RwLock;
-use ton_block::ShardIdent;
+use ever_block::ShardIdent;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::thread::JoinHandle;

--- a/node/src/service/message_api.rs
+++ b/node/src/service/message_api.rs
@@ -28,8 +28,7 @@ use std::{
     thread,
     time::Duration,
 };
-use ton_block::{Deserializable, Message};
-use ton_types::UInt256;
+use ever_block::{Deserializable, Message, UInt256};
 
 pub struct MessageReceiverApi;
 
@@ -120,7 +119,7 @@ impl MessageReceiverApi {
             }
         };
 
-        let message_cell = match ton_types::boc::read_single_root_boc(
+        let message_cell = match ever_block::boc::read_single_root_boc(
             &message_bytes,
         ) {
             Err(err) => {

--- a/node/src/service/mod.rs
+++ b/node/src/service/mod.rs
@@ -11,7 +11,7 @@ use router::Router;
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
-use ton_executor::BlockchainConfig;
+use ever_executor::BlockchainConfig;
 
 use self::engine_manager::TonNodeEngineManager;
 

--- a/node/src/tests/abi_account.rs
+++ b/node/src/tests/abi_account.rs
@@ -1,12 +1,13 @@
 use crate::tests::parse_address;
 use serde_json::{json, Value};
-use std::collections::HashMap;
 use std::io::Cursor;
 use std::sync::Arc;
-use ton_abi::token::Tokenizer;
-use ton_abi::Contract;
-use ton_block::{ExternalInboundMessageHeader, Message, MsgAddressExt, MsgAddressInt};
-use ton_types::{SliceData, Ed25519PrivateKey, ed25519_create_private_key};
+use ever_abi::token::Tokenizer;
+use ever_abi::Contract;
+use ever_block::{
+    ExternalInboundMessageHeader, Message, MsgAddressExt, MsgAddressInt, 
+    SliceData, Ed25519PrivateKey, ed25519_create_private_key
+};
 
 pub struct AbiAccount {
     pub(crate) address: MsgAddressInt,
@@ -39,8 +40,7 @@ impl AbiAccount {
                     &json!({
                         "time": (time as u64) * 1000,
                         "expire": time + 1,
-                    }),
-                    &HashMap::default(),
+                    })
                 )
                 .unwrap(),
                 &Tokenizer::tokenize_all_params(func.input_params(), &params).unwrap(),

--- a/node/src/tests/mod.rs
+++ b/node/src/tests/mod.rs
@@ -11,16 +11,14 @@ use std::io::Read;
 use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
-use ton_block::{
+use ever_block::{
     AccountStatus, Augmentation, BlkPrevInfo, Block, CurrencyCollection, Deserializable,
     ExtOutMessageHeader, ExternalInboundMessageHeader, HashmapAugType, InMsg,
     InternalMessageHeader, Message, MsgAddressExt, MsgAddressInt, OutMsg, Serializable, ShardIdent,
-    ShardStateUnsplit, Transaction, UnixTime32,
+    ShardStateUnsplit, Transaction, UnixTime32, AccountId, ByteOrderRead, Cell, HashmapType,
+    SliceData, UInt256
 };
-use ton_executor::BlockchainConfig;
-use ton_types::{
-    AccountId, ByteOrderRead, Cell, HashmapType, SliceData, UInt256,
-};
+use ever_executor::BlockchainConfig;
 
 mod abi_account;
 mod test_block_builder;
@@ -139,7 +137,7 @@ pub(crate) fn shard_state(storage: &ShardStorage) -> NodeResult<ShardStateUnspli
 fn shard_bag(storage: &ShardStorage) -> NodeResult<Cell> {
     let data = storage.get(shard_storage_key::SHARD_STATE_BLOCK_KEY)?;
     // TODO: BOC from file
-    Ok(ton_types::boc::read_single_root_boc(&data)?)
+    Ok(ever_block::boc::read_single_root_boc(&data)?)
 }
 
 ///
@@ -248,7 +246,7 @@ pub fn builder_add_test_transaction(
     builder: &mut BlockBuilder,
     in_msg: InMsg,
     out_msgs: &[OutMsg],
-) -> ton_types::Result<()> {
+) -> ever_block::Result<()> {
     log::debug!("Inserting test transaction");
     let tr_cell = in_msg.transaction_cell().unwrap();
     let transaction = Transaction::construct_from_cell(tr_cell.clone())?;

--- a/node/src/tests/test_block_builder.rs
+++ b/node/src/tests/test_block_builder.rs
@@ -1,7 +1,6 @@
 use rand::Rng;
 use std::{thread, time::{Duration, Instant}};
-use ton_block::*;
-use ton_types::*;
+use ever_block::*;
 use crate::tests::{builder_add_test_transaction, builder_is_empty, builder_with_shard_ident};
 
 macro_rules! println_elapsed{
@@ -126,7 +125,7 @@ fn test_blockbuilder_generate_blocks() {
         println_elapsed!("write block to builder", d);
 
         let now = Instant::now();
-        let buffer = ton_types::write_boc(&builder.into_cell().unwrap()).unwrap();
+        let buffer = ever_block::write_boc(&builder.into_cell().unwrap()).unwrap();
 
         let d = now.elapsed();
         println_elapsed!("serialize block to bag", d);
@@ -134,7 +133,7 @@ fn test_blockbuilder_generate_blocks() {
         // deserialize block
 
         let now = Instant::now();
-        let block_cells_restored = ton_types::boc::read_single_root_boc(&buffer).unwrap();
+        let block_cells_restored = ever_block::boc::read_single_root_boc(&buffer).unwrap();
 
         let d = now.elapsed();
         println_elapsed!("deserialize block from bag", d);

--- a/node/src/tests/test_block_finality.rs
+++ b/node/src/tests/test_block_finality.rs
@@ -5,7 +5,7 @@ use crate::tests::{
 };
 use std::io::Cursor;
 use std::sync::Arc;
-use ton_block::{
+use ever_block::{
     BlkPrevInfo, Block, ExtBlkRef, GetRepresentationHash, ShardIdent, ShardStateUnsplit,
 };
 

--- a/node/src/tests/test_file_based_storage.rs
+++ b/node/src/tests/test_file_based_storage.rs
@@ -4,8 +4,7 @@ use crate::data::{FSKVStorage, FSStorage, ShardStorage};
 use crate::tests::{
     generate_block_with_seq_no, get_block, save_block, save_shard_state, shard_state,
 };
-use ton_block::{BlkPrevInfo, HashmapAugType, Serializable, ShardIdent, ShardStateUnsplit};
-use ton_types::UInt256;
+use ever_block::{BlkPrevInfo, HashmapAugType, Serializable, ShardIdent, ShardStateUnsplit, UInt256};
 
 #[test]
 fn test_create_directory_tree() {

--- a/node/src/tests/test_messages.rs
+++ b/node/src/tests/test_messages.rs
@@ -1,6 +1,5 @@
 use std::{thread, time, sync::Arc};
-use ton_block::*;
-use ton_types::*;
+use ever_block::*;
 use crate::engine::InMessagesQueue;
 use crate::tests::{shard_state_info_deserialize, shard_state_info_with_params};
 

--- a/node/src/tests/test_node_se.rs
+++ b/node/src/tests/test_node_se.rs
@@ -1,8 +1,8 @@
-use ton_block::{GasLimitsPrices, MsgForwardPrices};
+use ever_block::{GasLimitsPrices, MsgForwardPrices};
 use crate::blockchain_config_from_json;
 
 #[test]
-fn test_blockchain_config_parsing() -> ton_types::Result<()> {
+fn test_blockchain_config_parsing() -> ever_block::Result<()> {
     let blockchain_config = blockchain_config_from_json(
         include_str!("blockchain.conf.json")
     )?;

--- a/node/src/tests/test_time_control.rs
+++ b/node/src/tests/test_time_control.rs
@@ -7,7 +7,7 @@ use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde_json::Value;
 use std::sync::Arc;
-use ton_block::ShardIdent;
+use ever_block::ShardIdent;
 
 const CFG_TEST: &str = include_str!("cfg_test");
 


### PR DESCRIPTION
Rust fixes.
Remove tests
ton_* -> ever_*
boc_readet as mutable
fix unused import
Fix tests
Fix integration tests