### PR TITLE
fix capabilities value fomat from hex to dec

### DIFF
--- a/docker/ton-node/blockchain.conf.json
+++ b/docker/ton-node/blockchain.conf.json
@@ -14,7 +14,7 @@
   ],
   "p8": {
     "version": 57,
-    "capabilities": "7E8827372E"
+    "capabilities": "543450150702"
   },
   "p9": [
     0,


### PR DESCRIPTION
**Step for test**
```bash
wget https://raw.githubusercontent.com/everx-labs/evernode-se/21d7da634caba6ba837d8a5b9be13377ad8d3b4f/docker/ton-node/blockchain.conf.json
docker rm -f ever
docker run --detach --name ever -p 80:80 -v $(pwd)/blockchain.conf.json:/ton-node/blockchain.conf.json tonlabs/local-node
curl -H "content-type: application/json" --data-raw '{"operationName":null,"variables":{},"query":"{blockchain {key_blocks(last: 1) { edges { node { master { config { p8 { version capabilities}}}}}}}}"}' http://localhost/graphql | jq
```
**out**
```json
{
  "data": {
    "blockchain": {
      "key_blocks": {
        "edges": [
          {
            "node": {
              "master": {
                "config": {
                  "p8": {
                    "version": 50,
                    "capabilities": "0x7e8827372e"
                  }
                }
              }
            }
          }
        ]
      }
    }
  }
}

```